### PR TITLE
feat: add as_pint to read_relative() and extract _apply_pint_dtype helper

### DIFF
--- a/tests/test_pint.py
+++ b/tests/test_pint.py
@@ -5,7 +5,7 @@ import pint
 import pint_pandas
 from datetime import datetime, timezone, timedelta
 
-from timedb.sdk import IncompatibleUnitError, _resolve_pint_values
+from timedb.sdk import IncompatibleUnitError, _resolve_pint_values, _apply_pint_dtype
 
 
 # =============================================================================
@@ -55,6 +55,50 @@ class TestResolvePintValues:
         s = pd.Series(pd.array([500.0, 1000.0, 1500.0], dtype="pint[kW]"), index=idx, name="value")
         result = _resolve_pint_values(s, "MW")
         assert list(result.index) == list(idx)
+
+
+class TestApplyPintDtype:
+    """Test the _apply_pint_dtype helper function."""
+
+    def test_empty_df_returns_unchanged(self):
+        """Empty DataFrame passes through unchanged."""
+        df = pd.DataFrame({
+            "valid_time": pd.Series([], dtype="datetime64[ns, UTC]"),
+            "value": pd.Series([], dtype="float64"),
+        })
+        result = _apply_pint_dtype(df, "MW")
+        assert len(result) == 0
+        assert result["value"].dtype == "float64"
+
+    def test_applies_pint_dtype(self):
+        """Value column gets pint dtype with correct unit."""
+        df = pd.DataFrame({
+            "valid_time": pd.to_datetime(["2026-01-01"], utc=True),
+            "value": [1.5],
+        })
+        result = _apply_pint_dtype(df, "MW")
+        assert hasattr(result["value"].dtype, 'units')
+        assert str(result["value"].dtype.units) == "megawatt"
+
+    def test_does_not_mutate_input(self):
+        """Original DataFrame is not mutated."""
+        df = pd.DataFrame({
+            "valid_time": pd.to_datetime(["2026-01-01"], utc=True),
+            "value": [1.5],
+        })
+        _apply_pint_dtype(df, "MW")
+        assert df["value"].dtype == "float64"
+
+    def test_magnitude_preserved(self):
+        """Numeric magnitudes are preserved after conversion."""
+        df = pd.DataFrame({
+            "valid_time": pd.to_datetime(["2026-01-01", "2026-01-02"], utc=True),
+            "value": [1.5, 2.5],
+        })
+        result = _apply_pint_dtype(df, "MW")
+        magnitudes = result["value"].values.quantity.magnitude
+        assert magnitudes[0] == pytest.approx(1.5)
+        assert magnitudes[1] == pytest.approx(2.5)
 
 
 # =============================================================================
@@ -144,5 +188,50 @@ def test_read_as_pint_false_default(td, sample_datetime):
     td.get_series("power").insert(df)
 
     df_read = td.get_series("power").read()
+    assert not hasattr(df_read["value"].dtype, 'units')
+    assert df_read["value"].dtype == "float64"
+
+
+def test_read_relative_as_pint(td, sample_datetime):
+    """read_relative with as_pint=True returns pint dtype column."""
+    td.create_series(name="wind_forecast", unit="MW", overlapping=True)
+
+    df = pd.DataFrame({
+        "valid_time": [sample_datetime, sample_datetime + timedelta(hours=1)],
+        "value": [10.0, 20.0],
+    })
+    td.get_series("wind_forecast").insert(
+        df, knowledge_time=sample_datetime - timedelta(hours=1)
+    )
+
+    df_pint = td.get_series("wind_forecast").read_relative(
+        window_length=timedelta(hours=24),
+        issue_offset=timedelta(hours=0),
+        start_window=sample_datetime,
+        as_pint=True,
+    )
+    assert hasattr(df_pint["value"].dtype, 'units')
+    assert str(df_pint["value"].dtype.units) == "megawatt"
+    assert df_pint["value"].values.quantity.magnitude[0] == pytest.approx(10.0)
+    assert df_pint["value"].values.quantity.magnitude[1] == pytest.approx(20.0)
+
+
+def test_read_relative_as_pint_false_default(td, sample_datetime):
+    """read_relative default returns plain float64."""
+    td.create_series(name="wind_forecast", unit="MW", overlapping=True)
+
+    df = pd.DataFrame({
+        "valid_time": [sample_datetime, sample_datetime + timedelta(hours=1)],
+        "value": [10.0, 20.0],
+    })
+    td.get_series("wind_forecast").insert(
+        df, knowledge_time=sample_datetime - timedelta(hours=1)
+    )
+
+    df_read = td.get_series("wind_forecast").read_relative(
+        window_length=timedelta(hours=24),
+        issue_offset=timedelta(hours=0),
+        start_window=sample_datetime,
+    )
     assert not hasattr(df_read["value"].dtype, 'units')
     assert df_read["value"].dtype == "float64"

--- a/timedb/sdk.py
+++ b/timedb/sdk.py
@@ -204,7 +204,9 @@ class SeriesCollection:
         - overlapping (overlapping=True): inserts into 'overlapping_{tier}' table with batch and knowledge_time
 
         Args:
-            df: DataFrame with columns [valid_time, value] or [valid_time, valid_time_end, value]
+            df: DataFrame with columns [valid_time, value] or [valid_time, valid_time_end, value].
+                The value column may also be a pint-typed array (e.g. ``pint[kW]``);
+                units are automatically converted to the series' registered unit.
             workflow_id: Workflow identifier (optional)
             batch_start_time: Start time (optional)
             batch_finish_time: Finish time (optional)
@@ -217,6 +219,8 @@ class SeriesCollection:
         Raises:
             ValueError: If collection matches multiple series (use more specific filters)
             ValueError: If DataFrame doesn't have the required columns
+            IncompatibleUnitError: If the value column has a pint dtype whose unit is not
+                dimensionally compatible with the series' registered unit.
         """
         series_id = self._get_single_id()
         routing = self._get_series_routing(series_id)
@@ -456,20 +460,8 @@ class SeriesCollection:
                     _pool=self._pool,
                 )
 
-        if as_pint and len(df) > 0:
-            try:
-                import pint
-                import pint_pandas  # noqa: F401
-            except ImportError:
-                raise ImportError(
-                    "as_pint=True requires pint and pint-pandas. "
-                    "Install with: pip install pint pint-pandas"
-                )
-            ureg = pint.application_registry.get()
-            pa = pint_pandas.PintArray.from_1darray_quantity(
-                pint.Quantity(df["value"].values, ureg(meta["unit"]))
-            )
-            df["value"] = pa
+        if as_pint:
+            df = _apply_pint_dtype(df, meta["unit"])
 
         return df
 
@@ -483,6 +475,7 @@ class SeriesCollection:
         *,
         days_ahead: Optional[int] = None,
         time_of_day: Optional[time] = None,
+        as_pint: bool = False,
     ) -> pd.DataFrame:
         """
         Read overlapping series using a per-window knowledge_time cutoff.
@@ -515,6 +508,8 @@ class SeriesCollection:
             start_valid: Start of valid time range. Also sets window alignment
                          (midnight of this date). Required in daily mode.
             end_valid: End of valid time range (optional)
+            as_pint: If True, return value column as pint dtype with the series'
+                registered unit. Requires pint and pint-pandas.
 
         Returns:
             DataFrame with index (valid_time,) and column (value).
@@ -522,6 +517,7 @@ class SeriesCollection:
         Raises:
             ValueError: If collection matches no series, multiple series,
                         series is not overlapping, or required parameters are missing/mixed.
+            ImportError: If as_pint=True but pint/pint-pandas not installed.
 
         Examples:
             >>> from datetime import datetime, timedelta, time, timezone
@@ -582,7 +578,7 @@ class SeriesCollection:
                 f"Series '{meta['name']}' is a flat series. Use read() instead."
             )
 
-        return _read_overlapping_relative(
+        df = _read_overlapping_relative(
             series_id=series_id,
             window_length=window_length,
             issue_offset=issue_offset,
@@ -591,6 +587,11 @@ class SeriesCollection:
             end_valid=end_valid,
             _pool=self._pool,
         )
+
+        if as_pint:
+            df = _apply_pint_dtype(df, meta["unit"])
+
+        return df
 
     def list_labels(self, label_key: str) -> List[str]:
         """List all unique values for a specific label key in this collection."""
@@ -953,6 +954,26 @@ def _resolve_pint_values(value_series: pd.Series, series_unit: str) -> pd.Series
 
     converted = magnitudes * factor
     return pd.Series(converted, index=value_series.index, name=value_series.name)
+
+
+def _apply_pint_dtype(df: pd.DataFrame, unit: str) -> pd.DataFrame:
+    if len(df) == 0:
+        return df
+    try:
+        import pint
+        import pint_pandas  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "as_pint=True requires pint and pint-pandas. "
+            "Install with: pip install pint pint-pandas"
+        )
+    ureg = pint.application_registry.get()
+    pa = pint_pandas.PintArray.from_1darray_quantity(
+        pint.Quantity(df["value"].values, ureg(unit))
+    )
+    df = df.copy()
+    df["value"] = pa
+    return df
 
 
 def _validate_df_columns(df: pd.DataFrame) -> bool:


### PR DESCRIPTION
## Summary

- Extract inline pint conversion from `read()` into a reusable `_apply_pint_dtype(df, unit)` helper (handles empty DataFrames, copies before mutating)
- Add `as_pint: bool = False` keyword-only parameter to `read_relative()`, matching the existing `read()` API
- Document pint-typed array support and `IncompatibleUnitError` on `insert()` docstring

## Test plan

- [x] Unit tests for `_apply_pint_dtype` (empty df, applies dtype, no mutation, magnitude preserved)
- [x] Integration tests for `read_relative(as_pint=True/False)`
- [x] Full test suite passes with no regressions (12 passed, 59 skipped)
- [x] No lint issues in changed files

Closes #8