### PR TITLE
fix: remove deprecated as_pint parameter from read()

### DIFF
--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -311,7 +311,6 @@ Full read signature:
        end_known=None,       # Optional, end of knowledge_time (overlapping only)
        overlapping=False,    # If True, return VERSIONED shape (overlapping only)
        include_updates=False,  # If True, include correction chain (CORRECTED/AUDIT shape)
-       as_pint=False,        # Deprecated; use ts.to_pandas() instead
    )
    df = ts.to_pandas()       # pd.DataFrame; index depends on shape (see DataShape)
 
@@ -329,9 +328,6 @@ To work with pint quantities, convert to pandas first and apply pint manually:
    # ts.unit == "MW"
    ureg = pint.UnitRegistry()
    qty = df["value"].values * ureg(ts.unit)  # pint Quantity array
-
-``as_pint=True`` is deprecated but still works for backward compatibility.
-Requires ``pip install timedb[pint]``.
 
 Reading Latest Values (Default)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_pint.py
+++ b/tests/test_pint.py
@@ -1,4 +1,4 @@
-"""Tests for pint unit support: insert conversion and read as_pint."""
+"""Tests for pint unit support: insert conversion."""
 import pytest
 import pandas as pd
 import pint
@@ -118,25 +118,8 @@ def test_insert_plain_float_no_unit_check(td, sample_datetime):
     assert df_read["value"].iloc[0] == pytest.approx(999.0)
 
 
-def test_read_as_pint(td, sample_datetime):
-    """Read with as_pint=True returns pint dtype column (deprecated path)."""
-    td.create_series(name="power", unit="MW")
-
-    df = pd.DataFrame({
-        "valid_time": [sample_datetime, sample_datetime + timedelta(hours=1)],
-        "value": [1.5, 2.5],
-    })
-    td.get_series("power").insert(df)
-
-    with pytest.warns(DeprecationWarning, match="as_pint=True is deprecated"):
-        df_pint = td.get_series("power").read(as_pint=True)
-    assert hasattr(df_pint["value"].dtype, 'units')
-    assert str(df_pint["value"].dtype.units) == "megawatt"
-    assert df_pint["value"].values.quantity.magnitude[0] == pytest.approx(1.5)
-
-
-def test_read_as_pint_false_default(td, sample_datetime):
-    """Read without as_pint returns a TimeSeries (default)."""
+def test_read_returns_timeseries(td, sample_datetime):
+    """Read returns a TimeSeries."""
     td.create_series(name="power", unit="MW")
 
     df = pd.DataFrame({

--- a/timedb/sdk.py
+++ b/timedb/sdk.py
@@ -17,7 +17,6 @@ Data model:
 import atexit
 import os
 import uuid
-import warnings
 from contextlib import contextmanager
 from typing import Optional, List, Tuple, NamedTuple, Dict, Union, Any
 from datetime import datetime, timedelta, timezone, time
@@ -323,8 +322,7 @@ class SeriesCollection:
         end_known: Optional[datetime] = None,
         overlapping: bool = False,
         include_updates: bool = False,
-        as_pint: bool = False,
-    ) -> Union["TimeSeries", pd.DataFrame]:
+    ) -> "TimeSeries":
         """
         Read time series data for this collection.
 
@@ -359,9 +357,6 @@ class SeriesCollection:
                   every model run and every correction ever made. Raises ValueError for flat.
                   Index: ``[knowledge_time, change_time, valid_time]``
 
-            as_pint: If True, return value column as pint dtype with series unit (default: False).
-                Requires pint and pint-pandas: pip install pint pint-pandas
-
         Returns:
             DataFrame with an index and columns that depend on the flag combination:
 
@@ -381,7 +376,6 @@ class SeriesCollection:
         Raises:
             ValueError: If collection matches multiple series, no series, or
                 ``overlapping=True`` is used with a flat series
-            ImportError: If as_pint=True but pint/pint-pandas not installed
 
         Example:
             >>> # Latest forecast — the single best value per timestamp
@@ -503,30 +497,6 @@ class SeriesCollection:
             description=meta.get("description"),
             timeseries_type=ts_type,
         )
-
-        if as_pint:
-            warnings.warn(
-                "as_pint=True is deprecated. "
-                "Call .to_pandas() on the returned TimeSeries instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if ts.num_rows > 0:
-                try:
-                    import pint
-                    import pint_pandas  # noqa: F401
-                except ImportError:
-                    raise ImportError(
-                        "as_pint=True requires pint and pint-pandas. "
-                        "Install with: pip install pint pint-pandas"
-                    )
-                ureg = pint.application_registry.get()
-                pdf = ts.to_pandas()
-                pint_arr = pint_pandas.PintArray.from_1darray_quantity(
-                    pint.Quantity(pdf["value"].values, ureg(meta["unit"]))
-                )
-                pdf["value"] = pint_arr
-                return pdf
 
         return ts
 


### PR DESCRIPTION
## Summary
- Remove the deprecated `as_pint` parameter from `SeriesCollection.read()`, simplifying the return type to always return `TimeSeries`
- Delete associated test (`test_read_as_pint`), rename `test_read_as_pint_false_default` → `test_read_returns_timeseries`
- Remove "Reading with Units" documentation section from `docs/sdk.rst`

Closes sub-issue 3 of #13.

## Test plan
- [x] `pytest tests/test_pint.py` — 6 passed, 5 skipped (DB-dependent)
- [ ] Full CI suite passes