### PR TITLE
fix: warn on dimensionless TimeSeries insert into non-dimensionless series

### DIFF
--- a/tests/test_pint.py
+++ b/tests/test_pint.py
@@ -5,7 +5,8 @@ import pint
 import pint_pandas
 from datetime import datetime, timezone, timedelta
 
-from timedb.sdk import IncompatibleUnitError, _resolve_pint_values
+import pyarrow as pa
+from timedb.sdk import IncompatibleUnitError, _resolve_pint_values, _resolve_arrow_units
 from timedb import TimeSeries
 
 
@@ -40,7 +41,15 @@ class TestResolvePintValues:
     def test_dimensionless_treated_as_series_unit(self):
         """Pint dimensionless is treated as series unit, stripped to float64."""
         s = pd.Series(pd.array([42.0], dtype="pint[dimensionless]"), name="value")
-        result = _resolve_pint_values(s, "MW")
+        with pytest.warns(UserWarning, match="dimensionless"):
+            result = _resolve_pint_values(s, "MW")
+        assert not hasattr(result.dtype, 'units')
+        assert result.iloc[0] == 42.0
+
+    def test_dimensionless_into_dimensionless_no_warning(self):
+        """Pint dimensionless into dimensionless series — no warning."""
+        s = pd.Series(pd.array([42.0], dtype="pint[dimensionless]"), name="value")
+        result = _resolve_pint_values(s, "dimensionless")
         assert not hasattr(result.dtype, 'units')
         assert result.iloc[0] == 42.0
 
@@ -56,6 +65,26 @@ class TestResolvePintValues:
         s = pd.Series(pd.array([500.0, 1000.0, 1500.0], dtype="pint[kW]"), index=idx, name="value")
         result = _resolve_pint_values(s, "MW")
         assert list(result.index) == list(idx)
+
+
+class TestResolveArrowUnits:
+    """Test the _resolve_arrow_units function in isolation."""
+
+    def test_dimensionless_into_non_dimensionless_warns(self):
+        table = pa.table({"value": [1.0, 2.0]})
+        with pytest.warns(UserWarning, match="dimensionless"):
+            result = _resolve_arrow_units(table, "dimensionless", "MW")
+        assert result == table
+
+    def test_dimensionless_into_dimensionless_no_warning(self):
+        table = pa.table({"value": [1.0, 2.0]})
+        result = _resolve_arrow_units(table, "dimensionless", "dimensionless")
+        assert result == table
+
+    def test_same_unit_no_warning(self):
+        table = pa.table({"value": [1.0, 2.0]})
+        result = _resolve_arrow_units(table, "MW", "MW")
+        assert result == table
 
 
 # =============================================================================

--- a/timedb/sdk.py
+++ b/timedb/sdk.py
@@ -1039,9 +1039,19 @@ def _resolve_pint_values(value_series: pd.Series, series_unit: str) -> pd.Series
     # Extract magnitudes (numpy array, no copy if already float64)
     magnitudes = value_series.values.quantity.magnitude
 
-    # Dimensionless or same unit → no conversion needed
+    # Same unit → no conversion needed
     ureg = pint.application_registry.get()
-    if ureg.dimensionless == ureg.Unit(source_unit) or source_unit == series_unit:
+    if source_unit == series_unit:
+        return pd.Series(magnitudes, index=value_series.index, name=value_series.name)
+    if ureg.dimensionless == ureg.Unit(source_unit):
+        if series_unit != "dimensionless":
+            warnings.warn(
+                f"Inserting a pint dimensionless array into series with unit "
+                f"'{series_unit}'. Values will be stored as-is without conversion. "
+                f"Use a pint array with the correct unit to enable automatic conversion.",
+                UserWarning,
+                stacklevel=4,
+            )
         return pd.Series(magnitudes, index=value_series.index, name=value_series.name)
 
     # Check compatibility and convert
@@ -1104,11 +1114,22 @@ def _resolve_arrow_units(table: pa.Table, ts_unit: str, series_unit: str) -> pa.
     """Scale the ``value`` column when *ts_unit* and *series_unit* differ.
 
     Rules:
-    - Same unit or ``ts_unit == "dimensionless"`` → return unchanged.
+    - Same unit → return unchanged.
+    - ``ts_unit == "dimensionless"`` → return unchanged, warn if *series_unit* is not dimensionless.
     - Compatible units → multiply ``value`` by the pint conversion factor.
     - Incompatible units → raise :class:`IncompatibleUnitError`.
     """
-    if ts_unit == series_unit or ts_unit == "dimensionless":
+    if ts_unit == series_unit:
+        return table
+    if ts_unit == "dimensionless":
+        if series_unit != "dimensionless":
+            warnings.warn(
+                f"Inserting a dimensionless TimeSeries into series with unit "
+                f"'{series_unit}'. Values will be stored as-is without conversion. "
+                f"Set the unit on your TimeSeries to enable automatic conversion.",
+                UserWarning,
+                stacklevel=4,
+            )
         return table
     try:
         import pint


### PR DESCRIPTION
## Summary
- Emit `UserWarning` when inserting dimensionless values (both pint arrays and arrow TimeSeries) into a series with a non-dimensionless unit
- Split the combined `dimensionless or same_unit` early-return in `_resolve_pint_values()` and `_resolve_arrow_units()` into separate checks
- Add tests for warning emission (and absence) in both code paths

Closes sub-issue 4 of #13.

## Test plan
- [x] `pytest tests/test_pint.py` — 10 passed, 6 skipped (DB-dependent)
- [ ] Full CI suite passes